### PR TITLE
enable NumLock (Num pad) on startup

### DIFF
--- a/files/autostart
+++ b/files/autostart
@@ -29,6 +29,9 @@ bash ~/.config/openbox/polybar/launch.sh
 ## Notification Daemon
 exec dunst &
 
+# enable num lock
+numlockx &
+
 ## Start Music Player Daemon
 exec mpd &
 


### PR DESCRIPTION
enable NumLock (Num pad) on startup