### PR TITLE
Fixed powermenu closing confirm dialog on double click

### DIFF
--- a/files/rofi/bin/powermenu
+++ b/files/rofi/bin/powermenu
@@ -45,6 +45,8 @@ show_msg() {
 options="$lock\n$suspend\n$logout\n$reboot\n$shutdown"
 
 chosen="$(echo -e "$options" | $rofi_command -p "UP - $uptime" -dmenu -selected-row 0)"
+# Small delay to prevent inadvertedly closing confirm dialog when using mouse double click
+sleep 0.1 
 case $chosen in
     $shutdown)
 		ans=$(rdialog &)


### PR DESCRIPTION
# Issue
When selecting an option from the power menu with the mouse (using double click), the confirm dialog appears to not open (in reality it is opened but closes immediately)

Basically this is the timeline:
=> left click down => left click up => left click down (double click registered, opening dialog) => left click up (dialog closes because it thinks the user clicked outside of the dialog)

# Solution
I added a small delay of 100ms just after selecting an option, this gives enough time for the release of the second mouse click and prevents rofi from thinking the user clicked outside of the confirm dialog.

This doesn't affect selection with keyboard (arrows + enter) and the delay is practically unnoticeable

This problem was mentionned in issue [archcraft#35](https://github.com/archcraft-os/archcraft/issues/35)