### PR TITLE
Fix polybar crash by removing excess double quote

### DIFF
--- a/files/themes/nord/polybar/config.ini
+++ b/files/themes/nord/polybar/config.ini
@@ -43,7 +43,7 @@ module-margin-right = 0
 
 font-0 = "Iosevka:size=10;3"
 font-1 = "Symbols Nerd Font:size=12;3"
-font-2 = "Iosevka:style=bold:"size=12;4"
+font-2 = "Iosevka:style=bold:size=12;4"
 font-3 = "Iosevka:size=6;3"
 
 modules-left = title sep openbox


### PR DESCRIPTION
Removed an extra ```"``` that would cause polybar to crash when attempting to load the "nord" theme.