### PR TITLE
Fix syntax error in bluetoothctl version comparison logic

### DIFF
--- a/files/themes/default/polybar/scripts/bluetooth.sh
+++ b/files/themes/default/polybar/scripts/bluetooth.sh
@@ -37,7 +37,8 @@ print_status() {
 		
         paired_devices_cmd="devices Paired"
         # Check if an outdated version of bluetoothctl is used to preserve backwards compatibility
-        if (( $(echo "$(bluetoothctl version | cut -d ' ' -f 2) < 5.65" | bc -l) )); then
+        version=$(bluetoothctl version | cut -d ' ' -f 2)
+        if [[ "$(printf '%s\n' "$version" 5.65 | sort -V | head -n1)" == "$version" && "$version" != "5.65" ]]; then
             paired_devices_cmd="paired-devices"
         fi
 


### PR DESCRIPTION
Added proper syntax for version checking in "default" theme polybar.