### PR TITLE
Fix syntax error for bluetoothctl version checking across all themes

### DIFF
--- a/files/themes/adaptive/polybar/scripts/bluetooth.sh
+++ b/files/themes/adaptive/polybar/scripts/bluetooth.sh
@@ -37,7 +37,8 @@ print_status() {
 		
         paired_devices_cmd="devices Paired"
         # Check if an outdated version of bluetoothctl is used to preserve backwards compatibility
-        if (( $(echo "$(bluetoothctl version | cut -d ' ' -f 2) < 5.65" | bc -l) )); then
+	version=$(bluetoothctl --version | cut -d ' ' -f 2)
+        if [[ "$version"  < "5.65" ]]; then
             paired_devices_cmd="paired-devices"
         fi
 

--- a/files/themes/beach/polybar/scripts/bluetooth.sh
+++ b/files/themes/beach/polybar/scripts/bluetooth.sh
@@ -37,7 +37,8 @@ print_status() {
 		
         paired_devices_cmd="devices Paired"
         # Check if an outdated version of bluetoothctl is used to preserve backwards compatibility
-        if (( $(echo "$(bluetoothctl version | cut -d ' ' -f 2) < 5.65" | bc -l) )); then
+	version=$(bluetoothctl --version | cut -d ' ' -f 2)
+        if [[ "$version"  < "5.65" ]]; then
             paired_devices_cmd="paired-devices"
         fi
 

--- a/files/themes/default/polybar/scripts/bluetooth.sh
+++ b/files/themes/default/polybar/scripts/bluetooth.sh
@@ -37,7 +37,8 @@ print_status() {
 		
         paired_devices_cmd="devices Paired"
         # Check if an outdated version of bluetoothctl is used to preserve backwards compatibility
-        if (( $(echo "$(bluetoothctl version | cut -d ' ' -f 2) < 5.65" | bc -l) )); then
+	version=$(bluetoothctl --version | cut -d ' ' -f 2)
+        if [[ "$version"  < "5.65" ]]; then
             paired_devices_cmd="paired-devices"
         fi
 

--- a/files/themes/easy/polybar/scripts/bluetooth.sh
+++ b/files/themes/easy/polybar/scripts/bluetooth.sh
@@ -37,7 +37,8 @@ print_status() {
 		
         paired_devices_cmd="devices Paired"
         # Check if an outdated version of bluetoothctl is used to preserve backwards compatibility
-        if (( $(echo "$(bluetoothctl version | cut -d ' ' -f 2) < 5.65" | bc -l) )); then
+		version=$(bluetoothctl --version | cut -d ' ' -f 2)
+        if [[ "$version"  < "5.65" ]]; then
             paired_devices_cmd="paired-devices"
         fi
 

--- a/files/themes/forest/polybar/scripts/bluetooth.sh
+++ b/files/themes/forest/polybar/scripts/bluetooth.sh
@@ -37,7 +37,8 @@ print_status() {
 		
         paired_devices_cmd="devices Paired"
         # Check if an outdated version of bluetoothctl is used to preserve backwards compatibility
-        if (( $(echo "$(bluetoothctl version | cut -d ' ' -f 2) < 5.65" | bc -l) )); then
+        version=$(bluetoothctl --version | cut -d ' ' -f 2)
+        if [[ "$version"  < "5.65" ]]; then
             paired_devices_cmd="paired-devices"
         fi
 

--- a/files/themes/gray/polybar/scripts/bluetooth.sh
+++ b/files/themes/gray/polybar/scripts/bluetooth.sh
@@ -37,7 +37,8 @@ print_status() {
 		
         paired_devices_cmd="devices Paired"
         # Check if an outdated version of bluetoothctl is used to preserve backwards compatibility
-        if (( $(echo "$(bluetoothctl version | cut -d ' ' -f 2) < 5.65" | bc -l) )); then
+        version=$(bluetoothctl --version | cut -d ' ' -f 2)
+        if [[ "$version"  < "5.65" ]]; then
             paired_devices_cmd="paired-devices"
         fi
 

--- a/files/themes/hack/polybar/scripts/bluetooth.sh
+++ b/files/themes/hack/polybar/scripts/bluetooth.sh
@@ -37,7 +37,8 @@ print_status() {
 		
         paired_devices_cmd="devices Paired"
         # Check if an outdated version of bluetoothctl is used to preserve backwards compatibility
-        if (( $(echo "$(bluetoothctl version | cut -d ' ' -f 2) < 5.65" | bc -l) )); then
+        version=$(bluetoothctl --version | cut -d ' ' -f 2)
+        if [[ "$version"  < "5.65" ]]; then
             paired_devices_cmd="paired-devices"
         fi
 

--- a/files/themes/kiss/polybar/scripts/bluetooth.sh
+++ b/files/themes/kiss/polybar/scripts/bluetooth.sh
@@ -37,7 +37,8 @@ print_status() {
 		
         paired_devices_cmd="devices Paired"
         # Check if an outdated version of bluetoothctl is used to preserve backwards compatibility
-        if (( $(echo "$(bluetoothctl version | cut -d ' ' -f 2) < 5.65" | bc -l) )); then
+        version=$(bluetoothctl --version | cut -d ' ' -f 2)
+        if [[ "$version"  < "5.65" ]]; then
             paired_devices_cmd="paired-devices"
         fi
 

--- a/files/themes/manhattan/polybar/scripts/bluetooth.sh
+++ b/files/themes/manhattan/polybar/scripts/bluetooth.sh
@@ -37,7 +37,8 @@ print_status() {
 		
         paired_devices_cmd="devices Paired"
         # Check if an outdated version of bluetoothctl is used to preserve backwards compatibility
-        if (( $(echo "$(bluetoothctl version | cut -d ' ' -f 2) < 5.65" | bc -l) )); then
+        version=$(bluetoothctl --version | cut -d ' ' -f 2)
+        if [[ "$version"  < "5.65" ]]; then
             paired_devices_cmd="paired-devices"
         fi
 

--- a/files/themes/nord/polybar/scripts/bluetooth.sh
+++ b/files/themes/nord/polybar/scripts/bluetooth.sh
@@ -37,7 +37,8 @@ print_status() {
 		
         paired_devices_cmd="devices Paired"
         # Check if an outdated version of bluetoothctl is used to preserve backwards compatibility
-        if (( $(echo "$(bluetoothctl version | cut -d ' ' -f 2) < 5.65" | bc -l) )); then
+        version=$(bluetoothctl --version | cut -d ' ' -f 2)
+        if [[ "$version"  < "5.65" ]]; then
             paired_devices_cmd="paired-devices"
         fi
 

--- a/files/themes/rainy/polybar/scripts/bluetooth.sh
+++ b/files/themes/rainy/polybar/scripts/bluetooth.sh
@@ -37,7 +37,8 @@ print_status() {
 		
         paired_devices_cmd="devices Paired"
         # Check if an outdated version of bluetoothctl is used to preserve backwards compatibility
-        if (( $(echo "$(bluetoothctl version | cut -d ' ' -f 2) < 5.65" | bc -l) )); then
+        version=$(bluetoothctl --version | cut -d ' ' -f 2)
+        if [[ "$version"  < "5.65" ]]; then
             paired_devices_cmd="paired-devices"
         fi
 

--- a/files/themes/red/polybar/scripts/bluetooth.sh
+++ b/files/themes/red/polybar/scripts/bluetooth.sh
@@ -37,7 +37,8 @@ print_status() {
 		
         paired_devices_cmd="devices Paired"
         # Check if an outdated version of bluetoothctl is used to preserve backwards compatibility
-        if (( $(echo "$(bluetoothctl version | cut -d ' ' -f 2) < 5.65" | bc -l) )); then
+        version=$(bluetoothctl --version | cut -d ' ' -f 2)
+        if [[ "$version"  < "5.65" ]]; then
             paired_devices_cmd="paired-devices"
         fi
 

--- a/files/themes/slime/polybar/scripts/bluetooth.sh
+++ b/files/themes/slime/polybar/scripts/bluetooth.sh
@@ -37,7 +37,8 @@ print_status() {
 		
         paired_devices_cmd="devices Paired"
         # Check if an outdated version of bluetoothctl is used to preserve backwards compatibility
-        if (( $(echo "$(bluetoothctl version | cut -d ' ' -f 2) < 5.65" | bc -l) )); then
+        version=$(bluetoothctl --version | cut -d ' ' -f 2)
+        if [[ "$version"  < "5.65" ]]; then
             paired_devices_cmd="paired-devices"
         fi
 

--- a/files/themes/spark/polybar/scripts/bluetooth.sh
+++ b/files/themes/spark/polybar/scripts/bluetooth.sh
@@ -37,7 +37,8 @@ print_status() {
 		
         paired_devices_cmd="devices Paired"
         # Check if an outdated version of bluetoothctl is used to preserve backwards compatibility
-        if (( $(echo "$(bluetoothctl version | cut -d ' ' -f 2) < 5.65" | bc -l) )); then
+        version=$(bluetoothctl --version | cut -d ' ' -f 2)
+        if [[ "$version"  < "5.65" ]]; then
             paired_devices_cmd="paired-devices"
         fi
 

--- a/files/themes/wave/polybar/scripts/bluetooth.sh
+++ b/files/themes/wave/polybar/scripts/bluetooth.sh
@@ -37,7 +37,8 @@ print_status() {
 		
         paired_devices_cmd="devices Paired"
         # Check if an outdated version of bluetoothctl is used to preserve backwards compatibility
-        if (( $(echo "$(bluetoothctl version | cut -d ' ' -f 2) < 5.65" | bc -l) )); then
+        version=$(bluetoothctl --version | cut -d ' ' -f 2)
+        if [[ "$version"  < "5.65" ]]; then
             paired_devices_cmd="paired-devices"
         fi
 


### PR DESCRIPTION
There is an existing PR ( #19 ) that contains a fix. However, it only fixes the default theme.

This PR fixes all themes. Additionally, I have tried to keep the fix as readable and simple as possible.